### PR TITLE
Use npm start instead of npm run dev

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-react: npm start
-electron: node src/electron-wait-react
+react: npm run react-start
+electron: npm run electron-start

--- a/package.json
+++ b/package.json
@@ -14,11 +14,12 @@
   "homepage": "./",
   "main": "src/electron-starter.js",
   "scripts": {
-    "start": "react-scripts start",
+    "start": "nf start -p 3000",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject",
     "electron": "electron .",
-    "dev" : "nf start -p 3000"
+    "electron-start": "node src/electron-wait-react",
+    "react-start": "react-scripts start"
   }
 }


### PR DESCRIPTION
* Change `npm start`'s behavior to be run by `npm run react-start`.
* Add a new npm script, `npm run electron-start`
* Change `Procfile` to run those two npm scripts, so all script behavior is defined within `package.json`.
* Change `npm run dev`'s behavior to be run by `npm start`, to be a little more consistent with other projects. Running `npm install` and `npm start` will start up the project for development.